### PR TITLE
fix: Panic running against Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/matoous/go-nanoid v1.5.0
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/tools v0.1.12
+	golang.org/x/tools v0.17.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,11 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## What

When running convergen 0.6.3 using Go 1.22, a panic is encountered.
This due to the old version of golang.org/x/tools on which this tool currently depends.

This issue was fixed in the tools library here: https://github.com/golang/go/issues/62167

Fixes #15

## How

```
go get golang.org/x/tools@v0.17.0
```

## Panic

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1025843f4]

goroutine 992 [running]:
go/types.(*Checker).handleBailout(0x14000914200, 0x1400076bc38)
	/usr/local/go/src/go/types/check.go:367 +0x9c
panic({0x1026c0060?, 0x1028b29e0?})
	/usr/local/go/src/runtime/panic.go:770 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x1027091d8, 0x1028b5e80})
	/usr/local/go/src/go/types/sizes.go:228 +0x314
go/types.(*Config).sizeof(...)
	/usr/local/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0x1027091d8?, 0x1028b5e80?})
	/usr/local/go/src/go/types/const.go:76 +0x9c
go/types.representableConst({0x10270a490, 0x1028ab380}, 0x14000914200, 0x1028b5e80, 0x14000767c28)
	/usr/local/go/src/go/types/const.go:92 +0x138
go/types.(*Checker).representation(0x14000914200, 0x14000762100, 0x1028b5e80)
	/usr/local/go/src/go/types/const.go:256 +0x68
go/types.(*Checker).implicitTypeAndValue(0x14000914200, 0x14000762100, {0x1027091d8, 0x1028b5e80})
	/usr/local/go/src/go/types/expr.go:375 +0x304
go/types.(*Checker).convertUntyped(0x14000914200, 0x14000762100, {0x1027091d8, 0x1028b5e80})
	/usr/local/go/src/go/types/const.go:289 +0x30
go/types.(*Checker).matchTypes(0x14000914200, 0x14000096900, 0x14000762100)
	/usr/local/go/src/go/types/expr.go:926 +0x7c
go/types.(*Checker).binary(0x14000914200, 0x14000096900, {0x1027099f0, 0x14000732d80}, {0x102709fc0, 0x140000960c0}, {0x102709f00, 0x14000092140}, 0x29, 0x3eee5)
	/usr/local/go/src/go/types/expr.go:800 +0x114
go/types.(*Checker).exprInternal(0x14000914200, 0x0, 0x14000096900, {0x1027099f0, 0x14000732d80}, {0x0, 0x0})
	/usr/local/go/src/go/types/expr.go:1416 +0x1d4
go/types.(*Checker).rawExpr(0x14000914200, 0x0, 0x14000096900, {0x1027099f0?, 0x14000732d80?}, {0x0?, 0x0?}, 0x0)
	/usr/local/go/src/go/types/expr.go:979 +0x12c
go/types.(*Checker).expr(0x14000914200, 0x0?, 0x14000096900, {0x1027099f0?, 0x14000732d80?})
	/usr/local/go/src/go/types/expr.go:1513 +0x38
go/types.(*Checker).binary(0x14000914200, 0x14000096900, {0x1027099f0, 0x14000732de0}, {0x1027099f0, 0x14000732d80}, {0x1027099f0, 0x14000732db0}, 0x22, 0x3eee9)
	/usr/local/go/src/go/types/expr.go:783 +0x70
go/types.(*Checker).exprInternal(0x14000914200, 0x0, 0x14000096900, {0x1027099f0, 0x14000732de0}, {0x0, 0x0})
	/usr/local/go/src/go/types/expr.go:1416 +0x1d4
go/types.(*Checker).rawExpr(0x14000914200, 0x0, 0x14000096900, {0x1027099f0?, 0x14000732de0?}, {0x0?, 0x0?}, 0x0)
	/usr/local/go/src/go/types/expr.go:979 +0x12c
go/types.(*Checker).expr(0x14000914200, 0x0?, 0x14000096900, {0x1027099f0?, 0x14000732de0?})
	/usr/local/go/src/go/types/expr.go:1513 +0x38
go/types.(*Checker).binary(0x14000914200, 0x14000096900, {0x1027099f0, 0x14000732ed0}, {0x1027099f0, 0x14000732de0}, {0x1027099f0, 0x14000732ea0}, 0x22, 0x3eef7)
	/usr/local/go/src/go/types/expr.go:783 +0x70
go/types.(*Checker).exprInternal(0x14000914200, 0x0, 0x14000096900, {0x1027099f0, 0x14000732ed0}, {0x0, 0x0})
	/usr/local/go/src/go/types/expr.go:1416 +0x1d4
go/types.(*Checker).rawExpr(0x14000914200, 0x0, 0x14000096900, {0x1027099f0?, 0x14000732ed0?}, {0x0?, 0x0?}, 0x0)
	/usr/local/go/src/go/types/expr.go:979 +0x12c
go/types.(*Checker).expr(0x14000914200, 0x1023d8d70?, 0x14000096900, {0x1027099f0?, 0x14000732ed0?})
	/usr/local/go/src/go/types/expr.go:1513 +0x38
go/types.(*Checker).binary(0x14000914200, 0x14000096900, {0x1027099f0, 0x14000732fc0}, {0x1027099f0, 0x14000732ed0}, {0x1027099f0, 0x14000732f90}, 0x22, 0x3ef44)
	/usr/local/go/src/go/types/expr.go:783 +0x70
go/types.(*Checker).exprInternal(0x14000914200, 0x0, 0x14000096900, {0x1027099f0, 0x14000732fc0}, {0x0, 0x0})
	/usr/local/go/src/go/types/expr.go:1416 +0x1d4
go/types.(*Checker).rawExpr(0x14000914200, 0x0, 0x14000096900, {0x1027099f0?, 0x14000732fc0?}, {0x0?, 0x0?}, 0x0)
	/usr/local/go/src/go/types/expr.go:979 +0x12c
go/types.(*Checker).expr(0x14000914200, 0x1028b5e60?, 0x14000096900, {0x1027099f0?, 0x14000732fc0?})
	/usr/local/go/src/go/types/expr.go:1513 +0x38
go/types.(*Checker).initVars(0x14000914200, {0x140003000e0, 0x1, 0x1025943bc?}, {0x140002b07b0, 0x102594300?, 0x140006a8d98?}, {0x102709c90, 0x14000092540?})
	/usr/local/go/src/go/types/assignments.go:381 +0x570
go/types.(*Checker).stmt(0x14000914200, 0x0, {0x102709c90, 0x14000092540})
	/usr/local/go/src/go/types/stmt.go:524 +0x1898
go/types.(*Checker).stmtList(0x14000914200, 0x0, {0x140002b07c0?, 0x0?, 0x0?})
	/usr/local/go/src/go/types/stmt.go:121 +0x88
go/types.(*Checker).funcBody(0x14000914200, 0x1027091d8?, {0x140002a2704?, 0x1028b5e60?}, 0x14000096740, 0x14000732ff0, {0x0?, 0x0?})
	/usr/local/go/src/go/types/stmt.go:41 +0x21c
go/types.(*Checker).funcDecl.func1()
	/usr/local/go/src/go/types/decl.go:852 +0x44
go/types.(*Checker).processDelayed(0x14000914200, 0x0)
	/usr/local/go/src/go/types/check.go:467 +0x12c
go/types.(*Checker).checkFiles(0x14000914200, {0x14000300000, 0x1, 0x1})
	/usr/local/go/src/go/types/check.go:411 +0x188
go/types.(*Checker).Files(...)
	/usr/local/go/src/go/types/check.go:372
golang.org/x/tools/go/packages.(*loader).loadPackage(0x140001941c0, 0x140004c7f60)
	/Users/ME/go/pkg/mod/golang.org/x/tools@v0.1.12/go/packages/packages.go:1001 +0x624
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
	/Users/ME/go/pkg/mod/golang.org/x/tools@v0.1.12/go/packages/packages.go:838 +0x178
sync.(*Once).doSlow(0x696d5f657261706d?, 0xa2c22732e787370?)
	/usr/local/go/src/sync/once.go:74 +0x100
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:65
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x5f657261706d6f63?, 0x22732e7830393373?)
	/Users/ME/go/pkg/mod/golang.org/x/tools@v0.1.12/go/packages/packages.go:826 +0x50
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1.1(0x2c22732e3436646d?)
	/Users/ME/go/pkg/mod/golang.org/x/tools@v0.1.12/go/packages/packages.go:833 +0x30
created by golang.org/x/tools/go/packages.(*loader).loadRecursive.func1 in goroutine 936
	/Users/ME/go/pkg/mod/golang.org/x/tools@v0.1.12/go/packages/packages.go:832 +0x84
exit status 2
convergen.go:8: running "go": exit status 1
```