### PR TITLE
feat: support additional args as mapping source

### DIFF
--- a/pkg/builder/assignment.go
+++ b/pkg/builder/assignment.go
@@ -462,7 +462,7 @@ func (b *assignmentBuilder) resolveTemplatedExpr(
 		return
 	}
 	index--
-	if int(index) >= len(additionalArgs) || index < 0 {
+	if index < 0 || len(additionalArgs) <= int(index) {
 		return
 	}
 	node = additionalArgs[index]

--- a/pkg/builder/assignment.go
+++ b/pkg/builder/assignment.go
@@ -5,6 +5,8 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strconv"
+	"strings"
 
 	bmodel "github.com/reedom/convergen/pkg/builder/model"
 	gmodel "github.com/reedom/convergen/pkg/generator/model"
@@ -22,32 +24,38 @@ type assignmentBuilder struct {
 	pkg     *packages.Package // The package the assignment belongs to.
 	imports util.ImportNames  // The import names to use in the generated code.
 
-	methodPos token.Pos      // The position of the method in the source code.
-	opts      option.Options // The options to use when generating the code.
-	lhsVar    gmodel.Var     // The variable on the left-hand side of the assignment.
-	rhsVar    gmodel.Var     // The variable on the right-hand side of the assignment.
-
-	funcName string           // The name of the method being generated.
-	copiers  []*bmodel.Copier // The list of copiers used in the generated code.
+	methodPos         token.Pos        // The position of the method in the source code.
+	opts              option.Options   // The options to use when generating the code.
+	lhsVar            gmodel.Var       // The variable on the left-hand side of the assignment.
+	rhsVar            gmodel.Var       // The variable on the right-hand side of the assignment.
+	additionalArgVars []gmodel.Var     // The additional arguments to use in the assignment.
+	funcName          string           // The name of the method being generated.
+	copiers           []*bmodel.Copier // The list of copiers used in the generated code.
 }
 
 // newAssignmentBuilder creates a new assignmentBuilder instance.
-func newAssignmentBuilder(p *FunctionBuilder, m *bmodel.MethodEntry, lhsVar, rhsVar gmodel.Var) *assignmentBuilder {
+func newAssignmentBuilder(
+	p *FunctionBuilder,
+	m *bmodel.MethodEntry,
+	lhsVar, rhsVar gmodel.Var,
+	additionalArgs []gmodel.Var,
+) *assignmentBuilder {
 	return &assignmentBuilder{
-		file:      p.file,
-		fset:      p.fset,
-		pkg:       p.pkg,
-		imports:   p.imports,
-		methodPos: m.Method.Pos(),
-		opts:      m.Opts,
-		lhsVar:    lhsVar,
-		rhsVar:    rhsVar,
-		funcName:  m.Name(),
+		file:              p.file,
+		fset:              p.fset,
+		pkg:               p.pkg,
+		imports:           p.imports,
+		methodPos:         m.Method.Pos(),
+		opts:              m.Opts,
+		lhsVar:            lhsVar,
+		rhsVar:            rhsVar,
+		additionalArgVars: additionalArgs,
+		funcName:          m.Name(),
 	}
 }
 
 // build generates the code for the assignment.
-func (b *assignmentBuilder) build(lhs, rhs *types.Var) ([]gmodel.Assignment, error) {
+func (b *assignmentBuilder) build(lhs, rhs *types.Var, additionalArgs []*types.Var) ([]gmodel.Assignment, error) {
 	rootCopier := bmodel.NewCopier("", lhs.Type(), rhs.Type())
 	rootCopier.IsRoot = true
 	if b.opts.Receiver != "" {
@@ -59,15 +67,20 @@ func (b *assignmentBuilder) build(lhs, rhs *types.Var) ([]gmodel.Assignment, err
 
 	rootLHS := bmodel.NewRootNode(b.lhsVar.Name, lhs.Type())
 	rootRHS := bmodel.NewRootNode(b.rhsVar.Name, rhs.Type())
-	return b.dispatch(rootLHS, rootRHS)
+
+	rootAdditionalArgs := make([]bmodel.Node, len(additionalArgs))
+	for i, arg := range additionalArgs {
+		rootAdditionalArgs[i] = bmodel.NewRootNode(b.additionalArgVars[i].Name, arg.Type())
+	}
+	return b.dispatch(rootLHS, rootRHS, rootAdditionalArgs)
 }
 
 // dispatch decides what type of assignment should be generated.
-func (b *assignmentBuilder) dispatch(lhs, rhs bmodel.Node) ([]gmodel.Assignment, error) {
+func (b *assignmentBuilder) dispatch(lhs, rhs bmodel.Node, additionalArgs []bmodel.Node) ([]gmodel.Assignment, error) {
 	lhsType := util.DerefPtr(lhs.ExprType())
 	rhsType := util.DerefPtr(rhs.ExprType())
 	if util.IsStructType(lhsType) && util.IsStructType(rhsType) {
-		return b.structToStruct(lhs, rhs)
+		return b.structToStruct(lhs, rhs, additionalArgs)
 	}
 
 	logger.Warnf("%v: no assignment %T to %T", b.fset.Position(b.methodPos), rhs.ExprType(), lhs.ExprType())
@@ -75,7 +88,7 @@ func (b *assignmentBuilder) dispatch(lhs, rhs bmodel.Node) ([]gmodel.Assignment,
 }
 
 // structToStruct generates code for a struct-to-struct assignment.
-func (b *assignmentBuilder) structToStruct(lhsStruct, rhsStruct bmodel.Node) ([]gmodel.Assignment, error) {
+func (b *assignmentBuilder) structToStruct(lhsStruct, rhsStruct bmodel.Node, additionalArgs []bmodel.Node) ([]gmodel.Assignment, error) {
 	var err error
 	var assignments []gmodel.Assignment
 	bmodel.IterateStructFields(lhsStruct, func(lhsField bmodel.Node) (done bool) {
@@ -84,7 +97,7 @@ func (b *assignmentBuilder) structToStruct(lhsStruct, rhsStruct bmodel.Node) ([]
 		}
 
 		var a gmodel.Assignment
-		a, err = b.matchStructFieldAndStruct(lhsField, rhsStruct)
+		a, err = b.matchStructFieldAndStruct(lhsField, rhsStruct, additionalArgs)
 		if err == nil && a != nil {
 			assignments = append(assignments, a)
 		}
@@ -98,7 +111,10 @@ func (b *assignmentBuilder) structToStruct(lhsStruct, rhsStruct bmodel.Node) ([]
 // not, tries to match the field with a converter, name mapper or literal
 // setter. If none of these match, it falls back to the
 // structFieldAndStructGettersAndFields method.
-func (b *assignmentBuilder) matchStructFieldAndStruct(lhs bmodel.Node, rhs bmodel.Node) (gmodel.Assignment, error) {
+func (b *assignmentBuilder) matchStructFieldAndStruct(
+	lhs, rhs bmodel.Node,
+	additionalArgs []bmodel.Node,
+) (gmodel.Assignment, error) {
 	if b.opts.ShouldSkip(lhs.MatcherExpr()) {
 		logger.Printf("%v: skip %v", b.fset.Position(b.methodPos), lhs.AssignExpr())
 		return gmodel.SkipField{LHS: lhs.AssignExpr()}, nil
@@ -110,7 +126,6 @@ func (b *assignmentBuilder) matchStructFieldAndStruct(lhs bmodel.Node, rhs bmode
 			return b.createWithConverter(lhs, rhs, converter)
 		}
 	}
-
 	for _, mapper := range b.opts.NameMapper {
 		if mapper.Dst().Match(lhs.MatcherExpr(), true) {
 			// If there are more than one mapper exist for the lhs, the first one wins.
@@ -118,6 +133,12 @@ func (b *assignmentBuilder) matchStructFieldAndStruct(lhs bmodel.Node, rhs bmode
 		}
 	}
 
+	for _, mapper := range b.opts.TemplatedNameMapper {
+		if mapper.Dst().Match(lhs.MatcherExpr(), true) {
+			// If there are more than one mapper exist for the lhs, the first one wins.
+			return b.createWithTemplatedMapper(lhs, rhs, additionalArgs, mapper)
+		}
+	}
 	for _, setter := range b.opts.Literals {
 		if setter.Dst().Match(lhs.MatcherExpr(), true) {
 			// If there are more than one mapper exist for the lhs, the first one wins.
@@ -176,7 +197,7 @@ func (b *assignmentBuilder) structFieldAndStructGettersAndFields(lhs bmodel.Node
 			if rhs.ObjNullable() {
 				nestStruct.NullCheckExpr = rhs.NullCheckExpr()
 			}
-			nestStruct.Contents, err = b.structToStruct(lhs, rhs)
+			nestStruct.Contents, err = b.structToStruct(lhs, rhs, nil)
 			if err == nil && 0 < len(nestStruct.Contents) {
 				a = nestStruct
 			}
@@ -277,6 +298,42 @@ func (b *assignmentBuilder) createWithMapper(lhs, rhs bmodel.Node, mapper *optio
 	return gmodel.NoMatchField{LHS: lhsExpr}, nil
 }
 
+// createWithTemplatedMapper creates an assignment for the given lhs node
+// using the provided name mapper and additional arguments.
+// It searches for a node in matches the mapper's source expression
+// and casts it to the lhs expression type.
+// If a match is found, it returns a SimpleField with the lhs and rhs expressions.
+// If a match is not found, it returns a NoMatchField with the lhs expression.
+func (b *assignmentBuilder) createWithTemplatedMapper(
+	lhs, rhs bmodel.Node,
+	additionalArgs []bmodel.Node,
+	mapper *option.NameMatcher,
+) (gmodel.Assignment, error) {
+	mappedNode := func() bmodel.Node {
+		args := []bmodel.Node{rhs}
+		args = append(args, additionalArgs...)
+		rhsNode, ok := b.resolveTemplatedExpr(mapper.Src(), args)
+		if !ok {
+			return nil
+		}
+
+		casted, _ := b.castNode(lhs.ExprType(), rhsNode)
+		return casted
+	}()
+
+	lhsExpr := lhs.AssignExpr()
+	posStr := b.fset.Position(mapper.Pos())
+
+	if mappedNode != nil {
+		rhsExpr := mappedNode.AssignExpr()
+		logger.Printf("%v: assignment found: %v = %s", posStr, lhs, rhsExpr)
+		return gmodel.SimpleField{LHS: lhsExpr, RHS: rhsExpr, Error: mappedNode.ReturnsError()}, nil
+	}
+
+	logger.Warnf("%v: no assignment for %v [%v]", posStr, lhsExpr, b.imports.TypeName(lhs.ExprType()))
+	return gmodel.NoMatchField{LHS: lhsExpr}, nil
+}
+
 // castNode tries to cast a given node to a target type.
 // It checks if the target type is assignable from the node type,
 // if not, it tries to convert to the target type, if possible.
@@ -343,6 +400,85 @@ func (b *assignmentBuilder) resolveExpr(matcher *option.IdentMatcher, root bmode
 			return
 		}
 
+		external := b.isExternalPkg(pkg)
+		if matcher.ForGetter(i) {
+			method, valid := obj.(*types.Func)
+			if !valid {
+				return
+			}
+			if external && !ast.IsExported(method.Name()) {
+				return
+			}
+
+			ret, retError, valid := util.ParseGetterReturnTypes(method)
+			if !valid {
+				return
+			}
+
+			node = bmodel.NewStructMethodNode(node, method)
+			if isLast {
+				return node, true
+			}
+
+			if retError {
+				// It should be a simple getter, otherwise it cannot be a part of method chain.
+				return
+			}
+			typ = ret
+		} else {
+			field, valid := obj.(*types.Var)
+			if !valid {
+				return
+			}
+			if external && !ast.IsExported(field.Name()) {
+				return
+			}
+
+			node = bmodel.NewStructFieldNode(node, field)
+			if isLast {
+				return node, true
+			}
+
+			typ = field.Type()
+		}
+	}
+	return
+}
+
+// resolveTemplatedExpr resolves the node that corresponds to the additional arguments
+// by following the path specified by the IdentMatcher.
+// It returns the resolved node and a boolean indicating whether the
+// resolution was successful.
+func (b *assignmentBuilder) resolveTemplatedExpr(
+	matcher *option.IdentMatcher,
+	additionalArgs []bmodel.Node,
+) (node bmodel.Node, ok bool) {
+	if matcher.PathLen() == 0 {
+		return
+	}
+	// arg index is 1-based
+	index, err := strconv.ParseInt(strings.Replace(matcher.ExprAt(0), "$", "", 1), 10, 64)
+	if err != nil {
+		return
+	}
+	index--
+	if int(index) >= len(additionalArgs) || index < 0 {
+		return
+	}
+	node = additionalArgs[index]
+	typ := node.ExprType()
+	if matcher.PathLen() == 1 {
+		return node, true
+	}
+
+	for i := 1; i < matcher.PathLen(); i++ {
+		isLast := matcher.PathLen() == i+1
+
+		pkg := util.PkgOf(typ)
+		obj, _, _ := types.LookupFieldOrMethod(typ, true, pkg, matcher.NameAt(i))
+		if obj == nil {
+			return
+		}
 		external := b.isExternalPkg(pkg)
 		if matcher.ForGetter(i) {
 			method, valid := obj.(*types.Func)

--- a/pkg/builder/method.go
+++ b/pkg/builder/method.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -57,12 +58,22 @@ func (p *FunctionBuilder) CreateFunction(m *bmodel.MethodEntry) (*gmodel.Functio
 	comments := util.ToTextList(m.DocComment)
 	src := m.SrcVar()
 	dst := m.DstVar()
+	additionalArgs := m.AdditionalArgVars()
+	// reverse cannot be used with additional arguments
+	if m.Opts.Reverse {
+		additionalArgs = nil
+	}
 
 	if util.IsInvalidType(src.Type()) {
 		return nil, logger.Errorf("%v: src type is not defined. make sure to be imported", p.fset.Position(src.Pos()))
 	}
-	if util.IsInvalidType(src.Type()) {
+	if util.IsInvalidType(dst.Type()) {
 		return nil, logger.Errorf("%v: dst type is not defined. make sure to be imported", p.fset.Position(dst.Pos()))
+	}
+	for _, arg := range additionalArgs {
+		if util.IsInvalidType(arg.Type()) {
+			return nil, logger.Errorf("%v: arg type is not defined. make sure to be imported", p.fset.Position(arg.Pos()))
+		}
 	}
 	if !util.IsStructType(util.DerefPtr(src.Type())) {
 		return nil, logger.Errorf("%v: src type should be a struct but %v", p.fset.Position(dst.Pos()), src.Type().Underlying().String())
@@ -79,7 +90,10 @@ func (p *FunctionBuilder) CreateFunction(m *bmodel.MethodEntry) (*gmodel.Functio
 
 	srcVar := p.createVar(src, srcDefName)
 	dstVar := p.createVar(dst, dstDefName)
-
+	additionalArgsVars := make([]gmodel.Var, len(additionalArgs))
+	for i, arg := range additionalArgs {
+		additionalArgsVars[i] = p.createVar(arg, fmt.Sprintf("arg%d", i))
+	}
 	if m.Opts.Receiver != "" {
 		if srcVar.External {
 			return nil, logger.Errorf("%v: an external package type cannot be a receiver", p.fset.Position(m.Method.Pos()))
@@ -90,36 +104,37 @@ func (p *FunctionBuilder) CreateFunction(m *bmodel.MethodEntry) (*gmodel.Functio
 	var assignments []gmodel.Assignment
 	var err error
 	if m.Opts.Reverse {
-		builder := newAssignmentBuilder(p, m, srcVar, dstVar)
-		assignments, err = builder.build(src, dst)
+		builder := newAssignmentBuilder(p, m, srcVar, dstVar, additionalArgsVars)
+		assignments, err = builder.build(src, dst, additionalArgs)
 	} else {
-		builder := newAssignmentBuilder(p, m, dstVar, srcVar)
-		assignments, err = builder.build(dst, src)
+		builder := newAssignmentBuilder(p, m, dstVar, srcVar, additionalArgsVars)
+		assignments, err = builder.build(dst, src, additionalArgs)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	preProcess, err := p.buildManipulator(m.Opts.PreProcess, src, dst, m.RetError())
+	preProcess, err := p.buildManipulator(m.Opts.PreProcess, src, dst, additionalArgs, m.RetError())
 	if err != nil {
 		return nil, err
 	}
-	postProcess, err := p.buildManipulator(m.Opts.PostProcess, src, dst, m.RetError())
+	postProcess, err := p.buildManipulator(m.Opts.PostProcess, src, dst, additionalArgs, m.RetError())
 	if err != nil {
 		return nil, err
 	}
 
 	fn := &gmodel.Function{
-		Name:        m.Method.Name(),
-		Comments:    comments,
-		Receiver:    m.Opts.Receiver,
-		Src:         srcVar,
-		Dst:         dstVar,
-		DstVarStyle: m.Opts.Style,
-		RetError:    m.RetError(),
-		Assignments: assignments,
-		PreProcess:  preProcess,
-		PostProcess: postProcess,
+		Name:           m.Method.Name(),
+		Comments:       comments,
+		Receiver:       m.Opts.Receiver,
+		Src:            srcVar,
+		Dst:            dstVar,
+		AdditionalArgs: additionalArgsVars,
+		DstVarStyle:    m.Opts.Style,
+		RetError:       m.RetError(),
+		Assignments:    assignments,
+		PreProcess:     preProcess,
+		PostProcess:    postProcess,
 	}
 
 	return fn, nil

--- a/pkg/builder/method.go
+++ b/pkg/builder/method.go
@@ -59,9 +59,9 @@ func (p *FunctionBuilder) CreateFunction(m *bmodel.MethodEntry) (*gmodel.Functio
 	src := m.SrcVar()
 	dst := m.DstVar()
 	additionalArgs := m.AdditionalArgVars()
-	// reverse cannot be used with additional arguments
-	if m.Opts.Reverse {
-		additionalArgs = nil
+
+	if m.Opts.Reverse && len(additionalArgs) > 0 {
+		return nil, logger.Errorf("%v: reverse cannot be used with additional arguments", p.fset.Position(m.Method.Pos()))
 	}
 
 	if util.IsInvalidType(src.Type()) {

--- a/pkg/builder/model/method.go
+++ b/pkg/builder/model/method.go
@@ -40,30 +40,6 @@ func (m *MethodEntry) Recv() types.Type {
 	return sig.Recv().Type()
 }
 
-// Args returns the argument types.
-func (m *MethodEntry) Args() []types.Type {
-	var list []types.Type
-
-	sig := m.Method.Type().(*types.Signature)
-	params := sig.Params()
-	results := sig.Results()
-
-	if m.Opts.Style == model.DstVarArg {
-		for i := 0; i < results.Len(); i++ {
-			list = append(list, results.At(i).Type())
-		}
-	}
-
-	i := 0
-	if m.Opts.Receiver != "" {
-		i = 1
-	}
-	for ; i < params.Len(); i++ {
-		list = append(list, params.At(i).Type())
-	}
-	return list
-}
-
 // Results returns the result types.
 func (m *MethodEntry) Results() []types.Type {
 	var list []types.Type
@@ -110,4 +86,17 @@ func (m *MethodEntry) DstVar() *types.Var {
 		return nil
 	}
 	return results.At(0)
+}
+
+// AdditionalArgVars returns the additional arguments.
+func (m *MethodEntry) AdditionalArgVars() []*types.Var {
+	sig := m.Method.Type().(*types.Signature)
+	params := make([]*types.Var, sig.Params().Len())
+	for i := 0; i < sig.Params().Len(); i++ {
+		params[i] = sig.Params().At(i)
+	}
+	if len(params) <= 1 {
+		return nil
+	}
+	return params[1:]
 }

--- a/pkg/builder/postprocess.go
+++ b/pkg/builder/postprocess.go
@@ -46,7 +46,7 @@ func (p *FunctionBuilder) buildManipulator(
 		return nil, logger.Errorf("%v: manipulator function %v 2nd arg type mismatch", p.fset.Position(m.Pos), ret.FuncName())
 	}
 
-	if len(m.AdditionalArgs) > 0 {
+	if 0 < len(m.AdditionalArgs) {
 		if len(m.AdditionalArgs) != len(additionalArgs) {
 			return nil, logger.Errorf("%v: manipulator function %v additional args count mismatch", p.fset.Position(m.Pos), ret.FuncName())
 		}
@@ -64,7 +64,7 @@ func (p *FunctionBuilder) buildManipulator(
 }
 
 func ordinalNumber(n int) string {
-	if n >= 11 && n <= 13 {
+	if 11 <= n && n <= 13 {
 		return fmt.Sprintf("%dth", n)
 	}
 	switch n % 10 {

--- a/pkg/generator/function.go
+++ b/pkg/generator/function.go
@@ -53,6 +53,14 @@ func (g *Generator) FuncToString(f *model.Function) string {
 		sb.WriteString(" ")
 		sb.WriteString(f.Src.FullType())
 	}
+
+	for _, args := range f.AdditionalArgs {
+		sb.WriteString(", ")
+		sb.WriteString(args.Name)
+		sb.WriteString(" ")
+		sb.WriteString(args.FullType())
+	}
+
 	// "func Name(dst *DstModel, src *SrcModel)"
 	sb.WriteString(") ")
 
@@ -90,13 +98,13 @@ func (g *Generator) FuncToString(f *model.Function) string {
 	}
 
 	if f.PreProcess != nil {
-		sb.WriteString(g.ManipulatorToString(f.PreProcess, f.Src, f.Dst))
+		sb.WriteString(g.ManipulatorToString(f.PreProcess, f.Src, f.Dst, f.AdditionalArgs))
 	}
 	for i := range f.Assignments {
 		sb.WriteString(AssignmentToString(f, f.Assignments[i]))
 	}
 	if f.PostProcess != nil {
-		sb.WriteString(g.ManipulatorToString(f.PostProcess, f.Src, f.Dst))
+		sb.WriteString(g.ManipulatorToString(f.PostProcess, f.Src, f.Dst, f.AdditionalArgs))
 	}
 	if f.RetError || f.DstVarStyle == model.DstVarReturn {
 		sb.WriteString("\nreturn\n")

--- a/pkg/generator/manipulator.go
+++ b/pkg/generator/manipulator.go
@@ -14,7 +14,7 @@ import (
 // - dst: the destination Var that corresponds to the Manipulator's second argument.
 // Returns:
 // - a string that represents the function call to the Manipulator.
-func (g *Generator) ManipulatorToString(m *model.Manipulator, src, dst model.Var) string {
+func (g *Generator) ManipulatorToString(m *model.Manipulator, src, dst model.Var, args []model.Var) string {
 	var sb strings.Builder
 	if m.RetError {
 		sb.WriteString("err = ")
@@ -44,6 +44,13 @@ func (g *Generator) ManipulatorToString(m *model.Manipulator, src, dst model.Var
 		}
 	}
 	sb.WriteString(src.Name)
+
+	if m.HasAdditionalArgs {
+		for _, arg := range args {
+			sb.WriteString(", ")
+			sb.WriteString(arg.Name)
+		}
+	}
 	sb.WriteString(")\n")
 
 	if m.RetError {

--- a/pkg/generator/model/function.go
+++ b/pkg/generator/model/function.go
@@ -8,14 +8,15 @@ type FunctionsBlock struct {
 
 // Function represents a function.
 type Function struct {
-	Comments    []string     // Comments is the list of comment lines before the function definition.
-	Name        string       // Name is the function name.
-	Receiver    string       // Receiver is the receiver type name, if any.
-	Src         Var          // Src is the source variable.
-	Dst         Var          // Dst is the destination variable.
-	RetError    bool         // RetError indicates whether the function returns an error.
-	DstVarStyle DstVarStyle  // DstVarStyle is the style of the destination variable declaration.
-	Assignments []Assignment // Assignments is the list of assignments in the function body.
-	PreProcess  *Manipulator // PreProcess is the function that is applied before the assignments.
-	PostProcess *Manipulator // PostProcess is the function that is applied after the assignments.
+	Comments       []string     // Comments is the list of comment lines before the function definition.
+	Name           string       // Name is the function name.
+	Receiver       string       // Receiver is the receiver type name, if any.
+	Src            Var          // Src is the source variable.
+	Dst            Var          // Dst is the destination variable.
+	AdditionalArgs []Var        // AdditionalArgs is the additional arguments variables.
+	RetError       bool         // RetError indicates whether the function returns an error.
+	DstVarStyle    DstVarStyle  // DstVarStyle is the style of the destination variable declaration.
+	Assignments    []Assignment // Assignments is the list of assignments in the function body.
+	PreProcess     *Manipulator // PreProcess is the function that is applied before the assignments.
+	PostProcess    *Manipulator // PostProcess is the function that is applied after the assignments.
 }

--- a/pkg/generator/model/manipulator.go
+++ b/pkg/generator/model/manipulator.go
@@ -4,11 +4,12 @@ import "fmt"
 
 // Manipulator represents a function that manipulates a value.
 type Manipulator struct {
-	Pkg      string // Pkg is the package name of the function.
-	Name     string // Name is the name of the function.
-	IsDstPtr bool   // IsDstPtr indicates that the first argument is a pointer to the destination.
-	IsSrcPtr bool   // IsSrcPtr indicates that the second argument is a pointer to the source.
-	RetError bool   // RetError indicates that the function returns an error.
+	Pkg               string // Pkg is the package name of the function.
+	Name              string // Name is the name of the function.
+	IsDstPtr          bool   // IsDstPtr indicates that the first argument is a pointer to the destination.
+	IsSrcPtr          bool   // IsSrcPtr indicates that the second argument is a pointer to the source.
+	HasAdditionalArgs bool   // HasAdditionalArgs indicates whether the function has additional arguments.
+	RetError          bool   // RetError indicates that the function returns an error.
 }
 
 // FuncName returns the fully qualified name of the function.

--- a/pkg/option/manipulator.go
+++ b/pkg/option/manipulator.go
@@ -7,9 +7,10 @@ import (
 
 // Manipulator represents a manipulator that manipulates the source and destination types.
 type Manipulator struct {
-	Func     types.Object // Func represents the function object that this manipulator invokes.
-	DstSide  types.Type   // DstSide is the type expression of the destination side.
-	SrcSide  types.Type   // SrcSide is the type expression of the source side.
-	RetError bool         // RetError indicates whether the manipulator returns an error or not.
-	Pos      token.Pos    // Pos represents the position of the manipulator in the source code.
+	Func           types.Object // Func represents the function object that this manipulator invokes.
+	DstSide        types.Type   // DstSide is the type expression of the destination side.
+	SrcSide        types.Type   // SrcSide is the type expression of the source side.
+	AdditionalArgs []types.Type // AdditionalArgs is the type expressions of the additional arguments.
+	RetError       bool         // RetError indicates whether the manipulator returns an error or not.
+	Pos            token.Pos    // Pos represents the position of the manipulator in the source code.
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -8,20 +8,21 @@ import (
 
 // Options represents the conversion options.
 type Options struct {
-	Style       model.DstVarStyle // Style of the destination variable name
-	Rule        model.MatchRule   // Matching rule for fields
-	ExactCase   bool              // Whether to match fields with exact case sensitivity
-	Getter      bool              // Whether to use getter methods to access fields
-	Stringer    bool              // Whether to use stringer methods to convert values to strings
-	Typecast    bool              // Whether to use explicit typecasts when converting values
-	Receiver    string            // Receiver name for method generation
-	Reverse     bool              // Whether to reverse the order of struct tags
-	SkipFields  []*PatternMatcher // List of field names to skip during conversion
-	NameMapper  []*NameMatcher    // List of field name mapping rules
-	Converters  []*FieldConverter // List of field conversion rules
-	Literals    []*LiteralSetter  // List of literal value setting rules
-	PreProcess  *Manipulator      // Manipulator to run before struct processing
-	PostProcess *Manipulator      // Manipulator to run after struct processing
+	Style               model.DstVarStyle // Style of the destination variable name
+	Rule                model.MatchRule   // Matching rule for fields
+	ExactCase           bool              // Whether to match fields with exact case sensitivity
+	Getter              bool              // Whether to use getter methods to access fields
+	Stringer            bool              // Whether to use stringer methods to convert values to strings
+	Typecast            bool              // Whether to use explicit typecasts when converting values
+	Receiver            string            // Receiver name for method generation
+	Reverse             bool              // Whether to reverse the order of struct tags
+	SkipFields          []*PatternMatcher // List of field names to skip during conversion
+	NameMapper          []*NameMatcher    // List of field name mapping rules
+	TemplatedNameMapper []*NameMatcher    // List of templated field name mapping rules
+	Converters          []*FieldConverter // List of field conversion rules
+	Literals            []*LiteralSetter  // List of literal value setting rules
+	PreProcess          *Manipulator      // Manipulator to run before struct processing
+	PostProcess         *Manipulator      // Manipulator to run after struct processing
 }
 
 // NewOptions returns a new Options instance.

--- a/pkg/parser/comment.go
+++ b/pkg/parser/comment.go
@@ -158,11 +158,6 @@ func (p *Parser) parseNotationInComments(notations []*ast.Comment, validOps map[
 	if opts.Reverse && opts.Style == gmodel.DstVarReturn {
 		return logger.Errorf(`%v: to use ":reverse", style must be ":style arg"`, p.fset.Position(posReverse))
 	}
-
-	if opts.Reverse && len(opts.TemplatedNameMapper) > 0 {
-		return logger.Errorf(`%v: :reverse cannot be used with :map that has additional arguments.`, p.fset.Position(posReverse))
-	}
-
 	return nil
 }
 

--- a/pkg/parser/comment.go
+++ b/pkg/parser/comment.go
@@ -105,8 +105,14 @@ func (p *Parser) parseNotationInComments(notations []*ast.Comment, validOps map[
 			if len(args) < 2 {
 				return logger.Errorf("%v: needs <src> <dst> args", p.fset.Position(n.Pos()))
 			}
-			matcher := option.NewNameMatcher(args[0], args[1], n.Pos())
-			opts.NameMapper = append(opts.NameMapper, matcher)
+			src := args[0]
+			dst := args[1]
+			matcher := option.NewNameMatcher(src, dst, n.Pos())
+			if strings.HasPrefix(src, "$") {
+				opts.TemplatedNameMapper = append(opts.TemplatedNameMapper, matcher)
+			} else {
+				opts.NameMapper = append(opts.NameMapper, matcher)
+			}
 		case "conv":
 			if len(args) < 2 {
 				return logger.Errorf("%v: needs <src> <dst> args", p.fset.Position(n.Pos()))
@@ -151,6 +157,10 @@ func (p *Parser) parseNotationInComments(notations []*ast.Comment, validOps map[
 	// validation
 	if opts.Reverse && opts.Style == gmodel.DstVarReturn {
 		return logger.Errorf(`%v: to use ":reverse", style must be ":style arg"`, p.fset.Position(posReverse))
+	}
+
+	if opts.Reverse && len(opts.TemplatedNameMapper) > 0 {
+		return logger.Errorf(`%v: :reverse cannot be used with :map that has additional arguments.`, p.fset.Position(posReverse))
 	}
 
 	return nil
@@ -261,17 +271,21 @@ func (p *Parser) lookupManipulatorFunc(funcName, optName string, pos token.Pos) 
 		return nil, logger.Errorf("%v: %v isn't a function", p.fset.Position(pos), funcName)
 	}
 
-	if sig.Params().Len() != 2 ||
-		1 < sig.Results().Len() ||
+	if 1 < sig.Results().Len() ||
 		(sig.Results().Len() == 1 && !util.IsErrorType(sig.Results().At(0).Type())) {
 		return nil, logger.Errorf("%v: function %v cannot use for %v func", p.fset.Position(pos), funcName, optName)
 	}
 
+	additionalArgs := make([]types.Type, sig.Params().Len()-2)
+	for i := 0; i < sig.Params().Len()-2; i++ {
+		additionalArgs[i] = sig.Params().At(i + 2).Type()
+	}
 	return &option.Manipulator{
-		Func:     obj,
-		DstSide:  sig.Params().At(0).Type(),
-		SrcSide:  sig.Params().At(1).Type(),
-		RetError: sig.Results().Len() == 1 && util.IsErrorType(sig.Results().At(0).Type()),
-		Pos:      pos,
+		Func:           obj,
+		DstSide:        sig.Params().At(0).Type(),
+		SrcSide:        sig.Params().At(1).Type(),
+		AdditionalArgs: additionalArgs,
+		RetError:       sig.Results().Len() == 1 && util.IsErrorType(sig.Results().At(0).Type()),
+		Pos:            pos,
 	}, nil
 }

--- a/tests/fixtures/usecase/maps/setup.gen.go
+++ b/tests/fixtures/usecase/maps/setup.gen.go
@@ -21,6 +21,39 @@ func (t *JSONDate) Time() time.Time {
 	return time.Time(*t)
 }
 
+type A struct {
+	JSONDate JSONDate
+	Value    int
+}
+
+type B struct {
+	JSONDate time.Time
+	Value    int
+	Arg0     uint
+	Arg1     string
+}
+
+type AdditionalArgs struct {
+	Arg1 string
+}
+
+func AToB(src *A, arg0 uint, arg1 AdditionalArgs) (dst *B) {
+	dst = &B{}
+	dst.JSONDate = src.JSONDate.Time()
+	dst.Value = src.Value
+	dst.Arg0 = arg0
+	dst.Arg1 = arg1.Arg1
+
+	return
+}
+
+func AToBArgStyle(dst *B, src *A, arg0 uint, arg1 AdditionalArgs) {
+	dst.JSONDate = src.JSONDate.Time()
+	dst.Value = src.Value
+	dst.Arg0 = arg0
+	dst.Arg1 = arg1.Arg1
+}
+
 func FromTo(src *From) (dst *To) {
 	dst = &To{}
 	dst.JSONDate = src.JSONDate.Time()

--- a/tests/fixtures/usecase/maps/setup.go
+++ b/tests/fixtures/usecase/maps/setup.go
@@ -20,8 +20,36 @@ func (t *JSONDate) Time() time.Time {
 	return time.Time(*t)
 }
 
+type A struct {
+	JSONDate JSONDate
+	Value    int
+}
+
+type B struct {
+	JSONDate time.Time
+	Value    int
+	Arg0     uint
+	Arg1     string
+}
+
+type AdditionalArgs struct {
+	Arg1 string
+}
+
 //go:generate go run github.com/reedom/convergen
 type Convergen interface {
 	// :map JSONDate.Time() JSONDate
 	FromTo(*From) *To
+	// :map JSONDate.Time() JSONDate
+	// :map $1.Value Value
+	// :map $2 Arg0
+	// :map $3.Arg1  Arg1
+	AToB(*A, uint, AdditionalArgs) *B
+
+	// :style arg
+	// :map JSONDate.Time() JSONDate
+	// :map $1.Value Value
+	// :map $2 Arg0
+	// :map $3.Arg1  Arg1
+	AToBArgStyle(*A, uint, AdditionalArgs) *B
 }

--- a/tests/fixtures/usecase/postprocess/setup.gen.go
+++ b/tests/fixtures/usecase/postprocess/setup.gen.go
@@ -10,6 +10,31 @@ import (
 	_ "github.com/reedom/convergen/tests/fixtures/usecase/postprocess/local"
 )
 
+type A struct {
+	Value int
+}
+
+type B struct {
+	Value int
+	Arg0  uint
+	Arg1  string
+}
+
+type AdditionalArgs struct {
+	Arg1 string
+}
+
+func AToB(src *A, arg0 uint, arg1 AdditionalArgs) (dst *B) {
+	dst = &B{}
+	PreAToB(dst, *src, arg0, arg1)
+	dst.Value = src.Value
+	// no match: dst.Arg0
+	// no match: dst.Arg1
+	PostAToB(dst, *src, arg0, arg1)
+
+	return
+}
+
 func DomainToModel(src *domain.Pet) (dst *model.Pet, err error) {
 	dst = &model.Pet{}
 	PreDomainToModel(dst, *src)
@@ -48,4 +73,12 @@ func PreDomainToModel(lhs *model.Pet, rhs domain.Pet) {
 
 func PostDomainToModel(lhs *model.Pet, rhs domain.Pet) error {
 	return nil
+}
+
+func PreAToB(lhs *B, rhs A, arg0 uint, arg1 AdditionalArgs) {
+
+}
+
+func PostAToB(lhs *B, rhs A, arg0 uint, arg1 AdditionalArgs) {
+
 }

--- a/tests/fixtures/usecase/postprocess/setup.go
+++ b/tests/fixtures/usecase/postprocess/setup.go
@@ -8,6 +8,20 @@ import (
 	_ "github.com/reedom/convergen/tests/fixtures/usecase/postprocess/local"
 )
 
+type A struct {
+	Value int
+}
+
+type B struct {
+	Value int
+	Arg0  uint
+	Arg1  string
+}
+
+type AdditionalArgs struct {
+	Arg1 string
+}
+
 //go:generate go run github.com/reedom/convergen
 type Convergen interface {
 	// :preprocess PreDomainToModel
@@ -15,6 +29,9 @@ type Convergen interface {
 	DomainToModel(*domain.Pet) (*model.Pet, error)
 	// :postprocess local.PostModelToDomain
 	ModelToDomain(*model.Pet) (*domain.Pet, error)
+	// :preprocess PreAToB
+	// :postprocess PostAToB
+	AToB(*A, uint, AdditionalArgs) *B
 }
 
 func PreDomainToModel(lhs *model.Pet, rhs domain.Pet) {
@@ -22,4 +39,12 @@ func PreDomainToModel(lhs *model.Pet, rhs domain.Pet) {
 
 func PostDomainToModel(lhs *model.Pet, rhs domain.Pet) error {
 	return nil
+}
+
+func PreAToB(lhs *B, rhs A, arg0 uint, arg1 AdditionalArgs) {
+
+}
+
+func PostAToB(lhs *B, rhs A, arg0 uint, arg1 AdditionalArgs) {
+
 }


### PR DESCRIPTION
Fixes #17

To extend the :map notation, it is now possible to assign template values such as `$1`, `$2`, and `$3` to the mapping sources. 
Template values start with `$1`, and additional arguments are assigned to `$2` and beyond(However, for compatibility reasons, the first argument `$1` is optional).
Also, preprocess and postprocess now support additional arguments.