### PR TITLE
feat: Correct module path for upcoming v8 major release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ lint:
 .PHONY: test
 test: ## Run all tests
 test:
-	go test github.com/reedom/convergen/tests && \
-	go test github.com/reedom/convergen/pkg/...
+	go test github.com/reedom/convergen/v8/tests && \
+	go test github.com/reedom/convergen/v8/pkg/...
 
 .PHONY: coverage
 coverage:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import (
     "github.com/sample/myapp/storage"
 )
 
-//go:generate go run github.com/reedom/convergen@v0.8.2
+//go:generate go run github.com/reedom/convergen@v8.0.3
 type Convergen interface {
     // :typecast
     // :stringer

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/reedom/convergen
+module github.com/reedom/convergen/v8
 
 go 1.23
 

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/reedom/convergen/pkg/config"
-	"github.com/reedom/convergen/pkg/runner"
+	"github.com/reedom/convergen/v8/pkg/config"
+	"github.com/reedom/convergen/v8/pkg/runner"
 )
 
 func main() {

--- a/pkg/builder/assignment.go
+++ b/pkg/builder/assignment.go
@@ -7,11 +7,11 @@ import (
 	"go/types"
 	"strconv"
 
-	bmodel "github.com/reedom/convergen/pkg/builder/model"
-	gmodel "github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	bmodel "github.com/reedom/convergen/v8/pkg/builder/model"
+	gmodel "github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 	"golang.org/x/tools/go/packages"
 )
 

--- a/pkg/builder/method.go
+++ b/pkg/builder/method.go
@@ -6,10 +6,10 @@ import (
 	"go/token"
 	"go/types"
 
-	bmodel "github.com/reedom/convergen/pkg/builder/model"
-	gmodel "github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/util"
+	bmodel "github.com/reedom/convergen/v8/pkg/builder/model"
+	gmodel "github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/util"
 	"golang.org/x/tools/go/packages"
 )
 

--- a/pkg/builder/model/copier.go
+++ b/pkg/builder/model/copier.go
@@ -3,7 +3,7 @@ package model
 import (
 	"go/types"
 
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 // Copier contains a helper function information.

--- a/pkg/builder/model/copier_test.go
+++ b/pkg/builder/model/copier_test.go
@@ -4,7 +4,7 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/builder/model"
+	"github.com/reedom/convergen/v8/pkg/builder/model"
 )
 
 func TestMarkHandle(t *testing.T) {

--- a/pkg/builder/model/method.go
+++ b/pkg/builder/model/method.go
@@ -4,9 +4,9 @@ import (
 	"go/ast"
 	"go/types"
 
-	"github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 // MethodsInfo contains a list of MethodEntry.

--- a/pkg/builder/model/method_test.go
+++ b/pkg/builder/model/method_test.go
@@ -8,8 +8,8 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/builder/model"
-	"github.com/reedom/convergen/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/builder/model"
+	"github.com/reedom/convergen/v8/pkg/option"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/builder/model/node.go
+++ b/pkg/builder/model/node.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"go/types"
 
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 type Node interface {

--- a/pkg/builder/model/node_test.go
+++ b/pkg/builder/model/node_test.go
@@ -5,8 +5,8 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/builder/model"
-	"github.com/reedom/convergen/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/builder/model"
+	"github.com/reedom/convergen/v8/pkg/option"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/builder/model/struct.go
+++ b/pkg/builder/model/struct.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"go/types"
 
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 // StructFieldNode represents a struct field.

--- a/pkg/builder/model/struct_test.go
+++ b/pkg/builder/model/struct_test.go
@@ -4,7 +4,7 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/builder/model"
+	"github.com/reedom/convergen/v8/pkg/builder/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/builder/model/util.go
+++ b/pkg/builder/model/util.go
@@ -3,7 +3,7 @@ package model
 import (
 	"go/types"
 
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 // IterateStructFields iterates through all the fields of the given structNode and

--- a/pkg/builder/postprocess.go
+++ b/pkg/builder/postprocess.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"go/types"
 
-	gmodel "github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	gmodel "github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 // buildManipulator builds a gmodel.Manipulator based on the given Manipulator

--- a/pkg/generator/assignment.go
+++ b/pkg/generator/assignment.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"strings"
 
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 )
 
 // AssignmentToString returns the string representation of the assignment.

--- a/pkg/generator/function.go
+++ b/pkg/generator/function.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"strings"
 	"regexp"
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 )
 
 // FuncToString generates the string representation of a given Function.

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 	"golang.org/x/tools/imports"
 )
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -3,16 +3,16 @@ package generator_test
 import (
 	"testing"
 
-	"github.com/reedom/convergen/pkg/generator"
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 	"github.com/stretchr/testify/assert"
 )
 
 const pre = `package simple
 
 import (
-	"github.com/reedom/convergen/pkg/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/pkg/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/pkg/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/pkg/tests/fixtures/data/model"
 )
 `
 

--- a/pkg/generator/manipulator.go
+++ b/pkg/generator/manipulator.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"strings"
 
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 )
 
 // ManipulatorToString returns a string representation of the given Manipulator.

--- a/pkg/generator/model/assignment_test.go
+++ b/pkg/generator/model/assignment_test.go
@@ -3,7 +3,7 @@ package model_test
 import (
 	"testing"
 
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/generator/model/enums_test.go
+++ b/pkg/generator/model/enums_test.go
@@ -3,7 +3,7 @@ package model_test
 import (
 	"testing"
 
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/option/field_converter_test.go
+++ b/pkg/option/field_converter_test.go
@@ -5,7 +5,7 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/option"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/option/literal_setter_test.go
+++ b/pkg/option/literal_setter_test.go
@@ -3,7 +3,7 @@ package option_test
 import (
 	"testing"
 
-	"github.com/reedom/convergen/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/option"
 )
 
 func TestIdentMatcher_Match(t *testing.T) {

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -3,7 +3,7 @@ package option
 import (
 	"strings"
 
-	"github.com/reedom/convergen/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
 )
 
 // Options represents the conversion options.

--- a/pkg/parser/comment.go
+++ b/pkg/parser/comment.go
@@ -8,11 +8,11 @@ import (
 	"regexp"
 	"strings"
 
-	bmodel "github.com/reedom/convergen/pkg/builder/model"
-	gmodel "github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	bmodel "github.com/reedom/convergen/v8/pkg/builder/model"
+	gmodel "github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 var (

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -5,9 +5,9 @@ import (
 	"unicode"
 
 	gonanoid "github.com/matoous/go-nanoid"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 const intfName = "Convergen"

--- a/pkg/parser/method.go
+++ b/pkg/parser/method.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/reedom/convergen/pkg/builder/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/builder/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 )
 
 var (

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/reedom/convergen/pkg/builder"
-	"github.com/reedom/convergen/pkg/builder/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/option"
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/builder"
+	"github.com/reedom/convergen/v8/pkg/builder/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/option"
+	"github.com/reedom/convergen/v8/pkg/util"
 	"golang.org/x/tools/go/packages"
 )
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,11 +3,11 @@ package runner
 import (
 	"os"
 
-	"github.com/reedom/convergen/pkg/config"
-	"github.com/reedom/convergen/pkg/generator"
-	"github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/parser"
+	"github.com/reedom/convergen/v8/pkg/config"
+	"github.com/reedom/convergen/v8/pkg/generator"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/parser"
 )
 
 // Run runs the convergen code generator using the provided configuration.

--- a/pkg/util/ast_test.go
+++ b/pkg/util/ast_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/util/import_test.go
+++ b/pkg/util/import_test.go
@@ -4,7 +4,7 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/util/types_test.go
+++ b/pkg/util/types_test.go
@@ -5,7 +5,7 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/util"
+	"github.com/reedom/convergen/v8/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/fixtures/usecase/additionalargs/setup.gen.go
+++ b/tests/fixtures/usecase/additionalargs/setup.gen.go
@@ -4,8 +4,8 @@
 package converter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/model"
-	"github.com/reedom/convergen/tests/fixtures/data/model/abc222"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model/abc222"
 )
 
 func DomainToModel(src *model.Additional, arg0 []abc222.Additional321) (dst *abc222.AdditionalItem123) {

--- a/tests/fixtures/usecase/additionalargs/setup.go
+++ b/tests/fixtures/usecase/additionalargs/setup.go
@@ -4,14 +4,13 @@
 package converter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/model"
-	"github.com/reedom/convergen/tests/fixtures/data/model/abc222"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model/abc222"
 )
 
 //go:generate go run github.com/reedom/convergen
 
-
 type Convergen interface {
 	//:map $2 List
-	DomainToModel(*model.Additional,[]abc222.Additional321) *abc222.AdditionalItem123
+	DomainToModel(*model.Additional, []abc222.Additional321) *abc222.AdditionalItem123
 }

--- a/tests/fixtures/usecase/converter/setup.gen.go
+++ b/tests/fixtures/usecase/converter/setup.gen.go
@@ -4,8 +4,8 @@
 package converter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 func DomainToModel(src *domain.Pet) (dst *model.Pet) {

--- a/tests/fixtures/usecase/converter/setup.go
+++ b/tests/fixtures/usecase/converter/setup.go
@@ -4,8 +4,8 @@
 package converter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/embedded/domain/domain.go
+++ b/tests/fixtures/usecase/embedded/domain/domain.go
@@ -1,7 +1,7 @@
 package domain
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/embedded/domain/types"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/embedded/domain/types"
 )
 
 type Concrete struct {

--- a/tests/fixtures/usecase/embedded/model/model.go
+++ b/tests/fixtures/usecase/embedded/model/model.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/embedded/model/types"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/embedded/model/types"
 )
 
 type Concrete struct {

--- a/tests/fixtures/usecase/embedded/setup.gen.go
+++ b/tests/fixtures/usecase/embedded/setup.gen.go
@@ -4,8 +4,8 @@
 package converter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/embedded/domain"
-	"github.com/reedom/convergen/tests/fixtures/usecase/embedded/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/embedded/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/embedded/model"
 )
 
 func DomainToModel(s *domain.Concrete) (d *model.Concrete) {

--- a/tests/fixtures/usecase/embedded/setup.go
+++ b/tests/fixtures/usecase/embedded/setup.go
@@ -4,8 +4,8 @@
 package converter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/embedded/domain"
-	"github.com/reedom/convergen/tests/fixtures/usecase/embedded/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/embedded/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/embedded/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/getter/setup.gen.go
+++ b/tests/fixtures/usecase/getter/setup.gen.go
@@ -4,8 +4,8 @@
 package getter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/ddd/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/ddd/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/ddd/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/ddd/model"
 )
 
 // DomainToModel copies domain.Pet to model.Pet.

--- a/tests/fixtures/usecase/getter/setup.go
+++ b/tests/fixtures/usecase/getter/setup.go
@@ -4,8 +4,8 @@
 package getter
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/ddd/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/ddd/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/ddd/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/ddd/model"
 )
 
 // :getter:off

--- a/tests/fixtures/usecase/literal/setup.gen.go
+++ b/tests/fixtures/usecase/literal/setup.gen.go
@@ -4,8 +4,8 @@
 package literal
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 func DomainToModel(src *domain.Pet) (dst *model.Pet) {

--- a/tests/fixtures/usecase/literal/setup.go
+++ b/tests/fixtures/usecase/literal/setup.go
@@ -3,8 +3,8 @@
 package literal
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/mapname/setup.gen.go
+++ b/tests/fixtures/usecase/mapname/setup.gen.go
@@ -4,8 +4,8 @@
 package mapname
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 func DomainToModel(src *domain.Pet) (dst *model.Pet) {

--- a/tests/fixtures/usecase/mapname/setup.go
+++ b/tests/fixtures/usecase/mapname/setup.go
@@ -4,8 +4,8 @@
 package mapname
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/nocase/setup.gen.go
+++ b/tests/fixtures/usecase/nocase/setup.gen.go
@@ -4,7 +4,7 @@
 package nocase
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/nocase/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/nocase/model"
 )
 
 type ModelA struct {

--- a/tests/fixtures/usecase/nocase/setup.go
+++ b/tests/fixtures/usecase/nocase/setup.go
@@ -3,7 +3,7 @@
 package nocase
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/nocase/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/nocase/model"
 )
 
 type ModelA struct {

--- a/tests/fixtures/usecase/postprocess/local/util.go
+++ b/tests/fixtures/usecase/postprocess/local/util.go
@@ -1,8 +1,8 @@
 package local
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 func PostModelToDomain(lhs *domain.Pet, rhs *model.Pet) error {

--- a/tests/fixtures/usecase/postprocess/setup.gen.go
+++ b/tests/fixtures/usecase/postprocess/setup.gen.go
@@ -4,10 +4,10 @@
 package postprocess
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
-	"github.com/reedom/convergen/tests/fixtures/usecase/postprocess/local"
-	_ "github.com/reedom/convergen/tests/fixtures/usecase/postprocess/local"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/postprocess/local"
+	_ "github.com/reedom/convergen/v8/tests/fixtures/usecase/postprocess/local"
 )
 
 type A struct {

--- a/tests/fixtures/usecase/postprocess/setup.go
+++ b/tests/fixtures/usecase/postprocess/setup.go
@@ -3,9 +3,9 @@
 package postprocess
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
-	_ "github.com/reedom/convergen/tests/fixtures/usecase/postprocess/local"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
+	_ "github.com/reedom/convergen/v8/tests/fixtures/usecase/postprocess/local"
 )
 
 type A struct {

--- a/tests/fixtures/usecase/ref/generated/setup.gen.go
+++ b/tests/fixtures/usecase/ref/generated/setup.gen.go
@@ -4,8 +4,8 @@
 package ref
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 func CatDomainToModel(src *domain.Category) (dst model.Category) {

--- a/tests/fixtures/usecase/ref/setup.go
+++ b/tests/fixtures/usecase/ref/setup.go
@@ -4,8 +4,8 @@
 package ref
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/simple/setup.gen.go
+++ b/tests/fixtures/usecase/simple/setup.gen.go
@@ -4,8 +4,8 @@
 package simple
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 func DomainToModel(src *domain.Pet) (dst *model.Pet) {

--- a/tests/fixtures/usecase/simple/setup.go
+++ b/tests/fixtures/usecase/simple/setup.go
@@ -3,8 +3,8 @@
 package simple
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/domain"
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/stringer/setup.gen.go
+++ b/tests/fixtures/usecase/stringer/setup.gen.go
@@ -4,8 +4,8 @@
 package stringer
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/model"
-	"github.com/reedom/convergen/tests/fixtures/usecase/stringer/local"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/stringer/local"
 )
 
 func LocalToModel(pet *local.Pet) (dst *model.Pet) {

--- a/tests/fixtures/usecase/stringer/setup.go
+++ b/tests/fixtures/usecase/stringer/setup.go
@@ -4,8 +4,8 @@
 package stringer
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/model"
-	"github.com/reedom/convergen/tests/fixtures/usecase/stringer/local"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/stringer/local"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/fixtures/usecase/style/setup.gen.go
+++ b/tests/fixtures/usecase/style/setup.gen.go
@@ -4,7 +4,7 @@
 package style
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 type Pet struct {

--- a/tests/fixtures/usecase/style/setup.go
+++ b/tests/fixtures/usecase/style/setup.go
@@ -3,7 +3,7 @@
 package style
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/data/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/data/model"
 )
 
 type Pet struct {

--- a/tests/fixtures/usecase/typecast/domain/user.go
+++ b/tests/fixtures/usecase/typecast/domain/user.go
@@ -1,7 +1,7 @@
 package domain
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/typecast/enums"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/typecast/enums"
 )
 
 type User struct {

--- a/tests/fixtures/usecase/typecast/setup.gen.go
+++ b/tests/fixtures/usecase/typecast/setup.gen.go
@@ -4,9 +4,9 @@
 package typecast
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/typecast/domain"
-	"github.com/reedom/convergen/tests/fixtures/usecase/typecast/enums"
-	"github.com/reedom/convergen/tests/fixtures/usecase/typecast/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/typecast/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/typecast/enums"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/typecast/model"
 )
 
 // DomainToModel converts domain.User to model.User.

--- a/tests/fixtures/usecase/typecast/setup.go
+++ b/tests/fixtures/usecase/typecast/setup.go
@@ -3,8 +3,8 @@
 package typecast
 
 import (
-	"github.com/reedom/convergen/tests/fixtures/usecase/typecast/domain"
-	"github.com/reedom/convergen/tests/fixtures/usecase/typecast/model"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/typecast/domain"
+	"github.com/reedom/convergen/v8/tests/fixtures/usecase/typecast/model"
 )
 
 //go:generate go run github.com/reedom/convergen

--- a/tests/usecases_test.go
+++ b/tests/usecases_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/reedom/convergen/pkg/generator"
-	"github.com/reedom/convergen/pkg/generator/model"
-	"github.com/reedom/convergen/pkg/logger"
-	"github.com/reedom/convergen/pkg/parser"
+	"github.com/reedom/convergen/v8/pkg/generator"
+	"github.com/reedom/convergen/v8/pkg/generator/model"
+	"github.com/reedom/convergen/v8/pkg/logger"
+	"github.com/reedom/convergen/v8/pkg/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Previously, I mistakenly tagged `v8.0.x` without updating the module path in `go.mod`.
This PR rectifies that by updating the `go.mod` file to `github.com/reedom/convergen/v8`.

This change adheres to Go's module versioning rules, which require a `/vN` suffix in the module path for major versions (v2+).
Going forward, `v8.x.x` versions of this module must be imported using the new path: `github.com/reedom/convergen/v8`.
