### PR TITLE
fix: apply :typecast only to potentially basic types

### DIFF
--- a/pkg/builder/assignment.go
+++ b/pkg/builder/assignment.go
@@ -351,7 +351,7 @@ func (b *assignmentBuilder) castNode(lhsType types.Type, rhs bmodel.Node) (c bmo
 		return b.castNode(lhsType, bmodel.NewStringer(rhs))
 	}
 
-	if b.opts.Typecast && types.ConvertibleTo(rhs.ExprType(), lhsType) {
+	if b.opts.Typecast && types.ConvertibleTo(rhs.ExprType(), lhsType) && util.IsBasicType(lhsType.Underlying()) {
 		c, ok = bmodel.NewTypecast(b.pkg.Types.Scope(), b.imports, lhsType, rhs)
 		if !ok {
 			logger.Warnf("%v: typecast for %v is not implemented(yet) for %v",

--- a/tests/fixtures/usecase/typecast/domain/user.go
+++ b/tests/fixtures/usecase/typecast/domain/user.go
@@ -8,4 +8,9 @@ type User struct {
 	ID     int
 	Name   string
 	Status enums.Status
+	Origin Origin
+}
+
+type Origin struct {
+	Region string
 }

--- a/tests/fixtures/usecase/typecast/model/user.go
+++ b/tests/fixtures/usecase/typecast/model/user.go
@@ -4,4 +4,9 @@ type User struct {
 	ID     int64
 	Name   string
 	Status string
+	Origin Origin
+}
+
+type Origin struct {
+	Region string
 }

--- a/tests/fixtures/usecase/typecast/setup.gen.go
+++ b/tests/fixtures/usecase/typecast/setup.gen.go
@@ -18,6 +18,7 @@ func DomainToModel(src *domain.User) (dst *model.User) {
 	dst.ID = int64(src.ID)
 	dst.Name = src.Name
 	dst.Status = string(src.Status)
+	dst.Origin.Region = src.Origin.Region
 
 	return
 }
@@ -32,6 +33,7 @@ func ModelToDomain(src *model.User) (dst *domain.User) {
 	dst.ID = int(src.ID)
 	dst.Name = src.Name
 	dst.Status = enums.Status(src.Status)
+	dst.Origin.Region = src.Origin.Region
 
 	return
 }


### PR DESCRIPTION
Previously, :typecast was incorrectly applied to structs as well.
